### PR TITLE
chore(sonar): rename project key and name to the current repo name

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,8 +1,8 @@
-sonar.projectKey=christian-wandling_demo-shop-public
+sonar.projectKey=christian-wandling_demo-shop-angular-nestjs
 sonar.organization=christian-wandling
 
 # This is the name and version displayed in the SonarCloud UI.
-sonar.projectName=demo-shop-public
+sonar.projectName=demo-shop-angular-nestjs
 sonar.projectVersion=1.0
 
 # Sources


### PR DESCRIPTION
Do not merge before the SonarCloud project has been rebound and its key updated. The scanner authenticates with this key; if SonarCloud has never seen it, auto-provisioning creates an empty project, resets the new-code baseline, and orphans the existing analysis history under the old name.

Refs: DES-2