### PR TITLE
fix(shared): override basic-ftp to ^5.2.2 to clear path-traversal alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21947,9 +21947,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "devOptional": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -160,5 +160,8 @@
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown",
     "*.(ts|tsx|js|jsx|html)": "node ./node_modules/eslint/bin/eslint.js --fix --ignore-pattern **.spec.* --ignore-pattern **/*-e2e/**"
+  },
+  "overrides": {
+    "basic-ftp": "^5.2.2"
   }
 }


### PR DESCRIPTION
Resolves basic-ftp 5.0.5 -> 5.3.1 (transitive via openapi-generator-cli), clearing GHSA-5rq4-664w-9x2c (critical) and GHSA-6v7q-wjvx-w8wg (high).

Refs: DES-78