### PR TITLE
chore: qualify dependabot ignores so security updates flow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,17 +19,65 @@ updates:
       - dependency-name: '*'
         update-types: ['version-update:semver-major']
       - dependency-name: '@angular/*'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
+          - 'version-update:semver-patch'
       - dependency-name: '@angular-devkit/*'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
+          - 'version-update:semver-patch'
       - dependency-name: '@schematics/angular'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
+          - 'version-update:semver-patch'
       - dependency-name: 'jest-preset-angular'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
+          - 'version-update:semver-patch'
       - dependency-name: '@nestjs/*'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
+          - 'version-update:semver-patch'
       - dependency-name: '@nrwl/*'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
+          - 'version-update:semver-patch'
       - dependency-name: 'nx'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
+          - 'version-update:semver-patch'
       - dependency-name: '@nx/*'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
+          - 'version-update:semver-patch'
       - dependency-name: 'rxjs'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
+          - 'version-update:semver-patch'
       - dependency-name: 'zone.js'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
+          - 'version-update:semver-patch'
       - dependency-name: 'typescript'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
+          - 'version-update:semver-patch'
       - dependency-name: '@types/node'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
+          - 'version-update:semver-patch'
     groups:
       dependencies:
         patterns:


### PR DESCRIPTION
## What

Qualifies every bare `dependency-name` ignore in `.github/dependabot.yml` (the twelve
Angular/Nx/NestJS-train patterns) with an explicit `update-types:` list covering
`version-update:semver-major|minor|patch`. Line 19's `*` entry already had this shape.

## Why

A bare `dependency-name` ignore suppresses **both** version updates and **security**
updates. That silently blocked the recent batch of Angular security alerts. Per GitHub
docs, `update-types` constrains **version** updates only and never touches security
updates — so scoping each ignore this way keeps routine version PRs suppressed while
letting security updates through.

## Intent preserved

Routine version bumps for the Angular / Nx / NestJS trains stay suppressed — those move
via `nx migrate`, not Dependabot. Only security updates newly flow.

## `open-pull-requests-limit: 2` left unchanged (intentional)

Security updates use a separate internal Dependabot limit of 10 that cannot be
configured; `open-pull-requests-limit` throttles only version-update PRs. So the current
limit of `2` does not gate security PRs and is safe as-is.

## Post-merge verification (pending — cannot be confirmed pre-merge)

Once merged, watch for a Dependabot **security** PR on packages matching the (now
qualified) ignored patterns. Currently-open alerts on those packages:

| Alert | Package | Pattern matched | Severity |
|-------|---------|-----------------|----------|
| #198  | `@nestjs/core` | `@nestjs/*` | medium |

That is the single concrete target: a security PR for `@nestjs/core` should appear after
merge (subject to a patched version being available). The Angular security alerts that
originally motivated this were already resolved by the 21.2.18 patch-bump (#113), so they
no longer appear as open alerts.

Refs: DES-88


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings to exclude selected development dependencies from major, minor, and patch update proposals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->