### PR TITLE
docs: add AGENTS.md with local dev, testing, and PR guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,7 @@ Angular frontend and NestJS API in one Nx monorepo, with a Postgres + Keycloak s
 ## Testing instructions
 - `npm run test` runs `nx run-many -t test`; `npm run lint` runs `nx run-many -t lint`.
 - Fix any failing test, type, or lint error before committing.
+
+## PR instructions
+- Commit format: `type(scope): subject` — lowercase, ≤72 chars, scope is an Nx project name or omitted.
+- Run `npm run lint` and `npm run test` green before pushing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,25 +1,15 @@
 # demo-shop-angular-nestjs
 
-Angular frontend and NestJS API in one Nx monorepo, with a Postgres + Keycloak dev stack via Docker Compose.
+Angular frontend and NestJS API in one Nx monorepo, with a Postgres + Keycloak stack via Docker Compose.
 
-## Local development
+## Dev environment tips
+- Copy `.env.example` to `.env`, then `docker compose up -d --build`. Frontend on `:4200`, API on `:3000`, Keycloak on `:8080`.
+- Initialize a fresh database with `docker compose exec api npx prisma migrate deploy`, then `npm run prisma:seed`.
+- Run the seed from the host, not the api container — it reaches Keycloak on `localhost:8080`.
+- The realm ships no users and registration is open; sign up in the browser to log in.
+- After a dependency bump, rebuild with `--renew-anon-volumes` or the `node_modules` volume shadows the new image.
+- After `docker compose down -v`, resync `KEYCLOAK_REALM_PUBLIC_KEY` in `.env` from `http://localhost:8080/realms/demo_shop`, or logins fail signature checks.
 
-Run from the repo root with a populated `.env` (copy `.env.example`):
-
-- `docker compose up -d --build` — db, keycloak (`:8080`), api (`:3000`), frontend (`:4200`), pgadmin.
-
-A fresh database volume has no schema or data:
-
-- `docker compose exec api npx prisma migrate deploy` — create the schema.
-- `npm run prisma:seed` — seed products, users, orders. Run from the **host**, not the api container: the seed reaches Keycloak on `localhost:8080`, which inside a container resolves to the container itself.
-
-The realm ships no users and registration is open — create an account in the browser to log in.
-
-Wiping the Keycloak volume (`docker compose down -v`) regenerates the realm signing keys, so the pinned `KEYCLOAK_REALM_PUBLIC_KEY` in `.env` goes stale and every login fails signature validation. Resync it from the `public_key` field of `http://localhost:8080/realms/demo_shop`, then recreate the api container.
-
-A dependency bump only reaches the running app after a rebuild that renews node_modules — `docker compose up -d --build --renew-anon-volumes --no-deps frontend` — because the `/app/node_modules` volume shadows the freshly built image otherwise.
-
-## Build and test
-
-- `npm run test` — `nx run-many -t test`.
-- `npm run lint` — `nx run-many -t lint`.
+## Testing instructions
+- `npm run test` runs `nx run-many -t test`; `npm run lint` runs `nx run-many -t lint`.
+- Fix any failing test, type, or lint error before committing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,12 +3,12 @@
 Angular frontend and NestJS API in one Nx monorepo, with a Postgres + Keycloak stack via Docker Compose.
 
 ## Dev environment tips
-- Copy `.env.example` to `.env`, then `docker compose up -d --build`. Frontend on `:4200`, API on `:3000`, Keycloak on `:8080`.
+- Copy `.env.example` to `.env`, then `docker compose up -d --build`. It publishes the frontend, API, and Keycloak on the ports set in `.env` (see `.env.example` for defaults).
 - Initialize a fresh database with `docker compose exec api npx prisma migrate deploy`, then `npm run prisma:seed`.
-- Run the seed from the host, not the api container — it reaches Keycloak on `localhost:8080`.
+- Run the seed from the host, not the api container — it reaches Keycloak on `localhost:${KEYCLOAK_PORT}`, which resolves to the container itself when run inside one.
 - The realm ships no users and registration is open; sign up in the browser to log in.
 - After a dependency bump, rebuild with `--renew-anon-volumes` or the `node_modules` volume shadows the new image.
-- After `docker compose down -v`, resync `KEYCLOAK_REALM_PUBLIC_KEY` in `.env` from `http://localhost:8080/realms/demo_shop`, or logins fail signature checks.
+- After `docker compose down -v`, resync `KEYCLOAK_REALM_PUBLIC_KEY` in `.env` from `http://localhost:${KEYCLOAK_PORT}/realms/demo_shop`, or logins fail signature checks.
 
 ## Testing instructions
 - `npm run test` runs `nx run-many -t test`; `npm run lint` runs `nx run-many -t lint`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# demo-shop-angular-nestjs
+
+Angular frontend and NestJS API in one Nx monorepo, with a Postgres + Keycloak dev stack via Docker Compose.
+
+## Local development
+
+Run from the repo root with a populated `.env` (copy `.env.example`):
+
+- `docker compose up -d --build` — db, keycloak (`:8080`), api (`:3000`), frontend (`:4200`), pgadmin.
+
+A fresh database volume has no schema or data:
+
+- `docker compose exec api npx prisma migrate deploy` — create the schema.
+- `npm run prisma:seed` — seed products, users, orders. Run from the **host**, not the api container: the seed reaches Keycloak on `localhost:8080`, which inside a container resolves to the container itself.
+
+The realm ships no users and registration is open — create an account in the browser to log in.
+
+Wiping the Keycloak volume (`docker compose down -v`) regenerates the realm signing keys, so the pinned `KEYCLOAK_REALM_PUBLIC_KEY` in `.env` goes stale and every login fails signature validation. Resync it from the `public_key` field of `http://localhost:8080/realms/demo_shop`, then recreate the api container.
+
+A dependency bump only reaches the running app after a rebuild that renews node_modules — `docker compose up -d --build --renew-anon-volumes --no-deps frontend` — because the `/app/node_modules` volume shadows the freshly built image otherwise.
+
+## Build and test
+
+- `npm run test` — `nx run-many -t test`.
+- `npm run lint` — `nx run-many -t lint`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,17 +3,11 @@
 Angular frontend and NestJS API in one Nx monorepo, with a Postgres + Keycloak stack via Docker Compose.
 
 ## Dev environment tips
-- Copy `.env.example` to `.env`, then `docker compose up -d --build`. It publishes the frontend, API, and Keycloak on the ports set in `.env` (see `.env.example` for defaults).
-- Initialize a fresh database with `docker compose exec api npx prisma migrate deploy`, then `npm run prisma:seed`.
-- Run the seed from the host, not the api container — it reaches Keycloak on `localhost:${KEYCLOAK_PORT}`, which resolves to the container itself when run inside one.
-- The realm ships no users and registration is open; sign up in the browser to log in.
-- After a dependency bump, rebuild with `--renew-anon-volumes` or the `node_modules` volume shadows the new image.
-- After `docker compose down -v`, resync `KEYCLOAK_REALM_PUBLIC_KEY` in `.env` from `http://localhost:${KEYCLOAK_PORT}/realms/demo_shop`, or logins fail signature checks.
-
-## Testing instructions
-- `npm run test` runs `nx run-many -t test`; `npm run lint` runs `nx run-many -t lint`.
-- Fix any failing test, type, or lint error before committing.
+- Copy `.env.example` to `.env`, then `docker compose up -d --build`. Ports come from `.env`.
+- Initialize a fresh database: `docker compose exec api npx prisma migrate deploy`, then `npm run prisma:seed` from the host.
+- Set `KEYCLOAK_REALM_PUBLIC_KEY` in `.env` to Keycloak's realm `public_key` from `/realms/demo_shop` after the first boot.
+- Register a user in the browser to log in.
+- Bump a dependency with `docker compose up -d --build --renew-anon-volumes`.
 
 ## PR instructions
-- Commit format: `type(scope): subject` — lowercase, ≤72 chars, scope is an Nx project name or omitted.
-- Run `npm run lint` and `npm run test` green before pushing.
+- A commit scope must be an Nx project name or omitted, enforced by commitlint `config-nx-scopes`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Adds a tracked `AGENTS.md` (plus `CLAUDE.md` → `@AGENTS.md`) in the agents.md house style.

Documents the local Docker stack and its non-obvious setup steps: host-run seed, `KEYCLOAK_REALM_PUBLIC_KEY` resync after a volume wipe, and `--renew-anon-volumes` so a dependency bump reaches the running app. Covers test/lint commands and commit conventions.

No behaviour change — docs only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an onboarding guide for the Angular frontend + NestJS API Nx monorepo demo, including Docker Compose startup, environment setup, database migration and seeding, authentication setup, and troubleshooting.
  * Added repository contribution standards, including commit message rules and an enforced Nx project scope convention.
  * Updated contributor documentation to reference the new onboarding guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->